### PR TITLE
Revisions following from test session

### DIFF
--- a/PentominoWithFurhat/assets/pentomino/src/App.js
+++ b/PentominoWithFurhat/assets/pentomino/src/App.js
@@ -16,6 +16,9 @@
  *        togglePopupWon()
  *        }                   [Zeile 106-111]
  *
+ *  - Die Spielzeit hat sich ins negative bewegt. Um dies zu beheben haben wir die Code Zeilen
+ *    aus [Zeile 277-279] nach [Zeile 339-241] bewegt.
+ *
  * Durch:
  * - Wencke Liermann, Lisa Plagemann, Niklas Stepczynski
  * - WiSe 20/21
@@ -273,6 +276,12 @@ const App = () => {
     setInitialShapes(generateElephantShape("elephant", pento_config, grid_config));
 
     dispatch({type: 'gameStart'})
+    if (gameTimeHandler.current){
+      clearInterval(gameTimeHandler.current)
+    }
+    gameTimeHandler.current = setInterval(() => {
+      dispatch({type: 'refreshTime'});
+    }, 500)
   };
 
   /**
@@ -330,9 +339,7 @@ const App = () => {
         const newPiece = pentoPieceToObj(el.name, el.type, el.color, el.x, el.y);
         dispatch({type: 'addToLeftBoard', piece: newPiece});
       });
-      gameTimeHandler.current = setInterval(() => {
-        dispatch({type: 'refreshTime'});
-      }, 500)
+
     }
 
     // Setzt den Alert für ein gewonnenes / verlorenes Spiel

--- a/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/flow/customGestures.kt
+++ b/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/flow/customGestures.kt
@@ -33,13 +33,14 @@ val LookAround = defineGesture("lookAround") {
 }
 
 // bow head to the front and look down
-val LookDown = defineGesture("lookDown") {
-    frame(0.5, 4.5) {
-        BasicParams.NECK_TILT to 10.0
-        BasicParams.LOOK_DOWN to 10.0
+fun LookDown(strength: Double = 1.0, duration: Double = 1.0) =
+    defineGesture("lookDown", strength, duration) {
+        frame(0.5, 4.5) {
+            BasicParams.NECK_TILT to 10.0
+            BasicParams.LOOK_DOWN to 10.0
+        }
+        reset(5.0)
     }
-    reset(5.0)
-}
 
 // reset all parameters of the gestures used in Idle
 val ReturnToNormal = defineGesture("ReturnToNormal") {

--- a/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/flow/general.kt
+++ b/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/flow/general.kt
@@ -28,14 +28,32 @@ import furhatos.util.*
 val GUI = HostedGUI("Pentomino", "assets/pentomino", 3000)
 var upToDate = true
 
-data class KnowledgeBase(
+class KnowledgeBase(
     var color: Colors? = null,
     var shape: Shapes? = null,
     var position: Positions = Positions()
-)
+) {
+    override fun toString(): String {
+        return "${this.color?.color?: run {""}} "+
+                "${this.shape?.shape?: run {""}} piece " +
+                "${this.position?.toString(detailed = true)}"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        when (other) {
+            is KnowledgeBase -> {
+                return this.color == other.color
+                        && this.shape == other.shape
+                        && this.position == other.position
+            }
+            else -> return false
+        }
+    }
+}
+
 
 // wait after send until furhat info was updated
-fun sendWait(name: String) = state {
+fun sendWait(name: String) = state(GameRunning){
     onEntry {
         upToDate = false
         send(name)
@@ -76,7 +94,7 @@ val Idle: State = state {
     }
 
     onTime(repeat=10000..15000) {
-        furhat.gesture(listOf(LookDown, GazeAway, LookAround).shuffled().take(1)[0], async = false)
+        furhat.gesture(listOf(LookDown(), GazeAway, LookAround).shuffled().take(1)[0], async = false)
     }
 
     // First look for a users that has never declined furhat's request before

--- a/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/nlu/nlu.kt
+++ b/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/nlu/nlu.kt
@@ -81,17 +81,17 @@ class Shapes(
     }
 
     private fun isPronoun(sent: String): Boolean {
-        if (shape !in setOf("U", "I")) {
+        if (this.text !in setOf("U", "you", "eye", "I")) {
             return false
         }
         val regex = Regex(
-            """(letter ${this.text})""" +
+            """\b((letter ${this.text})""" +
                     """|(character ${this.text})""" +
                     """|((a|(an)|(the)) (\w* ){0,2}${this.text})""" +
                     """|(capital (case)? ${this.text})""" +
                     """|(uppercase ${this.text})""" +
                     """|(of ${this.text})""" +
-                    """|(${this.text} shaped?)""" +
+                    """|(${this.text} shaped?))\b""" +
                     """|(^${this.text}$)""", RegexOption.IGNORE_CASE
         )
         if (regex.containsMatchIn(sent)) {
@@ -123,19 +123,19 @@ class Shapes(
 
 val ShapeGrammarEn =
     grammar {
-        rule(public = true) {
-            +("column"/"eye"/"I"/"line"/"long"/"pipe"/"ruler"/"stick"/"tube") tag {"I"}
-            +("bird"/"F"/"flower") tag {"F"}
-            +("hook"/"L") tag {"L"}
-            +("chair"/"coiling tube"/"duck"/"N"/"torch"/"winding pipe") tag {"N"}
-            +("block"/"open box"/"opened box"/"P"/"pea"/"pee"/"square") tag {"P"}
-            +("candle"/"hammer"/"T"/"tea"/"tee"/"tower"/"tree") tag {"T"}
-            +("bowl"/"box"/"bridge"/"c"/"cup"/"gate"/"U"/"you") tag {"U"}
-            +("angle"/"right angle"/"roof"/"tick"/"V") tag {"V"}
-            +("stairs"/"W"/"steps") tag {"W"}
-            +("X"/"cross"/"plus"/"star") tag {"X"}
-            +("hydrant"/"lego"/"pump"/"tap"/"water tap"/"why"/"Y") tag {"Y"}
-            +("duck"/"mirrored S"/"reflected S"/"S"/"swan"/"Z") tag {"Z"}
+        rule("shape", public = true) {
+            +("column" / "eye" / "I" / "I-shaped" / "line" / "long" / "pipe" / "ruler" / "stick" / "tube") tag { "I" }
+            +("bird" / "F" / "F-shaped" / "flower") tag { "F" }
+            +("hook" / "L" / "L-shaped") tag { "L" }
+            +("chair" / "coiling tube" / "duck" / "N" / "N-shaped" / "torch" / "winding pipe") tag { "N" }
+            +("block" / "open box" / "opened box" / "P" / "P-shaped" / "pea" / "pee" / "square") tag { "P" }
+            +("candle" / "hammer" / "T" / "T-shaped" / "tea" / "tee" / "tower" / "tree") tag { "T" }
+            +("bowl" / "box" / "bridge" / "C" / "C-shaped" / "cup" / "gate" / "U" / "U-shaped" / "you") tag { "U" }
+            +("angle" / "right angle" / "roof" / "tick" / "V" / "V-shaped") tag { "V" }
+            +("stairs" / "steps" / "W" / "W-shaped") tag { "W" }
+            +("cross" / "plus" / "star"/ "X" / "X-shaped") tag { "X" }
+            +("hydrant" / "lego" / "pump" / "tap" / "water tap" / "why" / "Y" / "Y-shaped") tag { "Y" }
+            +("duck" / "mirrored S" / "reflected S" / "S" / "S-shaped" / "swan" / "Z" / "Z-shaped") tag { "Z" }
         }
     }
 


### PR DESCRIPTION
+ Consideration: Do we really want the user to describe the last piece? Answer: No, the last piece is picked automatically from now on. For that purpose we sacrificed the <Last> intent
+ Negative Example: Gaze is in the wrong direction and a glance to the right Board not enough - Solution: replace gaze by attend and change x-values
+ Consideration: Add peer, peen as version of 'P' - Answer: Rejected.
+ Consideration: If furhat gets wrong information, how should it deal with it. For now he just ignores restrictions that are to strong and lead to an empty set of candidates. - Answer: We want him to act as before if even without the ignores information he can unambiguously identify a piece, but if the remaining info is ambiguous he now discards all information.
"Do you want to play again?" -> NO ... bisschen mehr geste
+ Furhat takes a short break after user interrupted him
+ Consideration: "Did you mean that one or that one?" if ambigous input - Answer: No longer necessary with above changes to the handling of wrong input
+ Negative Example: 'u-shaped' not recognized as 'U' - Causes: Tokenization Approach ('-' not used as word border)  - Solution: add '.-shaped' for all letters, words other than letters are generally not written with hypen
+ Negative Example: Two times 'no' in explanation, but still goes on with the game after the second time. - Causes: Polarity of some random questions was off - Solution: restate questions
ask- delay times erhöhen?
beim nachfragen, die pronomen handeln
+ Negative Example: "Can you take the yellow piece?" - Causes: Identifies 'you' as a letter because the regex "an .*" matches - Solution: add \b at the beginning
+ Negative Example: if furhat misunderstood you e.g. identified the color red through the recognized word 'wet', then while stating what he got he repeats this mistake - Causes: We printed the intent (= raw text) and not the extracted tag - Solution: Print tag
+ Negative Example: only one piece to go, after starting a second game - Causes: information not updated as the gamefinished state does not catch the update event - Solution: repair timer and let gamefinished inherent from gamerunning
+ Negative Example: "Oh I am sorry! Can we try another piece" + "next description, please!" = odd repetition - Causes: voice lines - Solution: minor changes on voice lines