### PR TITLE
Add gray elephant template

### DIFF
--- a/PentominoWithFurhat/assets/pentomino/src/App.js
+++ b/PentominoWithFurhat/assets/pentomino/src/App.js
@@ -270,7 +270,8 @@ const App = () => {
    * Rendert die Buttons unter dem Game-Board, mit denen zu Testzwecken einzelne Teile ausgewählt werden können.
    */
   const renderButtons = () => {
-    return initialShapes.concat(placedShapes).sort().map(element => {
+    return initialShapes.concat(placedShapes.filter(s => s.color == pento_config.templ_col)
+    ).sort().map(element => {
       return <button id={"pento_" + element.type}
                      style={{ visibility: gameState.correctly_placed.find(shape => shape.name == element.name)?'hidden':'visible'}}
                      onClick={() => {
@@ -482,7 +483,15 @@ const App = () => {
 
     // ALle aktuell ausgewählten Spielsteine löschen
     setActiveShape([]);
-    setInitialShapes(generateElephantShape("elephant", pento_config, grid_config));
+    let [origin, goal] = generateElephantShape("elephant", pento_config, grid_config);
+    setInitialShapes(origin);
+
+    if (pento_config.provide_template) {
+      setPlacedShapes(goal);
+      for (let temp_piece of goal) {
+        dispatch({type: 'pieceAtGoal', piece: temp_piece})
+      }
+    }
 
     dispatch({type: 'gameStart'})
     if (gameTimeHandler.current){
@@ -580,7 +589,8 @@ const App = () => {
   useEffect(() => {
     // Wenn auf beiden Boards keine Steine mehr verfügbar sind (alle korrekt plaziert sind)
     // und das Spiel noch läuft, haben wir gewonnen
-    if (gameState.game.status === 'ongoing' && gameState.correctly_placed?.length === 12) {
+    if (gameState.game.status === 'ongoing'
+        && gameState.correctly_placed?.length === 2*pento_config.get_pento_types().length) {
       dispatch({type: 'gameWon'});
     }
 
@@ -722,7 +732,6 @@ const App = () => {
           <div className="six columns">
           </div>
           <div className="six columns">
-            <div>Tets</div>
             <div style={{ color: "#555", fontSize: "16px" }}>Game State: {gameState.game.status}</div>
             <div style={{ color: "#555", fontSize: "16px" }}>Remaining Game Time: {gameState.game.time}</div>
           </div>

--- a/PentominoWithFurhat/assets/pentomino/src/config.js
+++ b/PentominoWithFurhat/assets/pentomino/src/config.js
@@ -19,9 +19,12 @@ export class PentoConfig {
             '#99BBDD': 'light blue',
             '#336699': 'dark blue',
             '#5CD6D6': 'turquoise',
-            '#FFB366': 'orange'
+            '#FFB366': 'orange',
+            '#e8e8e8': 'gray'
         };
 
+        this.templ_col = 'gray'
+        this.provide_template = true
         this.board_size = board_size;
         this.n_blocks = n_blocks;
         this.block_size = board_size / n_blocks;
@@ -49,6 +52,15 @@ export class PentoConfig {
 
     get_color_name(color_code) {
         return this.color_map[color_code]
+    }
+
+    get_hex_code(color_name) {
+        for (let c in this.color_map) {
+            if (this.color_map[c] == color_name) {
+                return c
+            }
+        }
+        return "" //TODO: throw error
     }
 
     /**

--- a/PentominoWithFurhat/assets/pentomino/src/pento-objects/HelperDrawComplexShapes.js
+++ b/PentominoWithFurhat/assets/pentomino/src/pento-objects/HelperDrawComplexShapes.js
@@ -1,5 +1,6 @@
 import {grid_cell_to_coordinates} from "./HelperDrawingBoard";
 import {pento_create_shape} from "./HelperPentoShapes";
+import {PentoConfig} from "../config";
 
 export const configPerShape = (shape, n_blocks) => {
 
@@ -43,7 +44,6 @@ export const configPerShape = (shape, n_blocks) => {
  * This generates all shapes that are required to fill the elephant
  */
 export const generateElephantShape = (shape, pento_config, grid_config) => {
-
     // set value ranges for random selection
     const columns =			[...Array(grid_config.n_blocks).keys()];
     const rows =				[...Array(grid_config.n_blocks).keys()];
@@ -53,22 +53,29 @@ export const generateElephantShape = (shape, pento_config, grid_config) => {
     const pento_types =		pento_config.get_pento_types();
 
     let generated_shapes = 	[];
+    let template_shapes = [];
 
     for (let id=0; id<pento_types.length; id++) {
         let rand_color = colors[Math.floor(Math.random() * colors.length)];
+        // while rand_color grey choose new color
+        while (pento_config.get_color_name(rand_color) == pento_config.templ_col) {
+            rand_color = colors[Math.floor(Math.random() * colors.length)];
+        }
 
         const pento_types =		pento_config.get_pento_types();
         let pento_piece = pento_types[id]
 
-
         let new_shape = createNewPentoPieceInShape(shape, grid_config, pento_piece, rand_color, id);
+        let new_template = createNewPentoPieceInShape(shape, grid_config, pento_piece, pento_config.get_hex_code(pento_config.templ_col), id);
         generated_shapes.push(new_shape.copy(id));
+        template_shapes.push(new_template.copy(generated_shapes.length + id));
     }
+
 
     // now move, rotate, flip shape randomly to create initial board
     create_initial_state(generated_shapes, ['rotate', 'move', 'flip'], grid_config);
 
-    return generated_shapes
+    return [generated_shapes, template_shapes];
 };
 
 export const createNewPentoPieceInShape = (shape, grid_config, pento_piece, color, id) => {

--- a/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/flow/interaction.kt
+++ b/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/flow/interaction.kt
@@ -384,7 +384,7 @@ val VerifyInformation : State = state(GameRunning) {
 
     onEntry {
         furhat.glance(users.current)
-        furhat.say("Ok. I seem to have missed out on some information.")
+        furhat.say("Ok. I seem to be missing some information.")
         furhat.say("Here is, what I have:")
         furhat.glance(users.current)
         furhat.say(

--- a/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/nlu/nlu.kt
+++ b/PentominoWithFurhat/src/main/kotlin/furhatos/app/pentominowithfurhat/nlu/nlu.kt
@@ -127,7 +127,7 @@ val ShapeGrammarEn =
             +("column" / "eye" / "I" / "I-shaped" / "line" / "long" / "pipe" / "ruler" / "stick" / "tube") tag { "I" }
             +("bird" / "F" / "F-shaped" / "flower") tag { "F" }
             +("hook" / "L" / "L-shaped") tag { "L" }
-            +("chair" / "coiling tube" / "duck" / "N" / "N-shaped" / "torch" / "winding pipe") tag { "N" }
+            +("chair" / "coiling tube" / "duck"/ "M" / "M-shaped" / "N" / "N-shaped" / "torch" / "winding pipe") tag { "N" }
             +("block" / "open box" / "opened box" / "P" / "P-shaped" / "pea" / "pee" / "square") tag { "P" }
             +("candle" / "hammer" / "T" / "T-shaped" / "tea" / "tee" / "tower" / "tree") tag { "T" }
             +("bowl" / "box" / "bridge" / "C" / "C-shaped" / "cup" / "gate" / "U" / "U-shaped" / "you") tag { "U" }


### PR DESCRIPTION
In order to guide the user in their task to build
an elephant out of the pieces. We implemented the possibility
to show a template on the right side.
This template can be disabled via the option 'provide_template'
in the config file. For the template we added a gray color to
the color_map.